### PR TITLE
Add custom namespacing to bridged ROS interfaces

### DIFF
--- a/micro_ros_agent/CMakeLists.txt
+++ b/micro_ros_agent/CMakeLists.txt
@@ -56,6 +56,7 @@ add_executable(${PROJECT_NAME}
   src/agent/graph_manager/graph_manager.cpp
   src/agent/graph_manager/graph_typesupport.cpp
   src/agent/utils/demangle.cpp
+  src/agent/utils/namespace.cpp
   )
 
 target_include_directories(${PROJECT_NAME}

--- a/micro_ros_agent/cmake/SuperBuild.cmake
+++ b/micro_ros_agent/cmake/SuperBuild.cmake
@@ -23,10 +23,13 @@ unset(xrceagent_DIR CACHE)
 find_package(xrceagent 2 EXACT QUIET)
 if(NOT xrceagent_FOUND)
     ExternalProject_Add(xrceagent
-            GIT_REPOSITORY
-                https://github.com/eProsima/Micro-XRCE-DDS-Agent.git
-            GIT_TAG
-                v2.4.3
+            SOURCE_DIR
+                /home/jh/Micro-XRCE-DDS-Agent # Temp path for testing, will be changed to the bit repo later
+            # Commented out original git source:
+            # GIT_REPOSITORY
+            #     https://github.com/eProsima/Micro-XRCE-DDS-Agent.git
+            # GIT_TAG
+            #     v2.4.3
             PREFIX
                 ${PROJECT_BINARY_DIR}/agent
             INSTALL_DIR

--- a/micro_ros_agent/cmake/SuperBuild.cmake
+++ b/micro_ros_agent/cmake/SuperBuild.cmake
@@ -23,13 +23,10 @@ unset(xrceagent_DIR CACHE)
 find_package(xrceagent 2 EXACT QUIET)
 if(NOT xrceagent_FOUND)
     ExternalProject_Add(xrceagent
-            SOURCE_DIR
-                /home/jh/Micro-XRCE-DDS-Agent # Temp path for testing, will be changed to the bit repo later
-            # Commented out original git source:
-            # GIT_REPOSITORY
-            #     https://github.com/eProsima/Micro-XRCE-DDS-Agent.git
-            # GIT_TAG
-            #     v2.4.3
+            GIT_REPOSITORY
+                https://github.com/fictionlab/Micro-XRCE-DDS-Agent.git
+            GIT_TAG
+                8d66eb245e21bc30ab57cddfbdae53628b2b740e
             PREFIX
                 ${PROJECT_BINARY_DIR}/agent
             INSTALL_DIR

--- a/micro_ros_agent/cmake/SuperBuild.cmake
+++ b/micro_ros_agent/cmake/SuperBuild.cmake
@@ -26,7 +26,7 @@ if(NOT xrceagent_FOUND)
             GIT_REPOSITORY
                 https://github.com/fictionlab/Micro-XRCE-DDS-Agent.git
             GIT_TAG
-                8d66eb245e21bc30ab57cddfbdae53628b2b740e
+                v2.4.3-fictionlab1
             PREFIX
                 ${PROJECT_BINARY_DIR}/agent
             INSTALL_DIR

--- a/micro_ros_agent/include/agent/Agent.hpp
+++ b/micro_ros_agent/include/agent/Agent.hpp
@@ -21,8 +21,6 @@
 
 #include <agent/graph_manager/graph_manager.hpp>
 
-#include <fastrtps/attributes/TopicAttributes.h>
-
 #include <map>
 #include <memory>
 

--- a/micro_ros_agent/include/agent/Agent.hpp
+++ b/micro_ros_agent/include/agent/Agent.hpp
@@ -21,6 +21,8 @@
 
 #include <agent/graph_manager/graph_manager.hpp>
 
+#include <fastrtps/attributes/TopicAttributes.h>
+
 #include <map>
 #include <memory>
 
@@ -46,6 +48,7 @@ private:
 
     eprosima::uxr::AgentInstance& xrce_dds_agent_instance_;
     std::map<eprosima::fastdds::dds::DomainId_t, std::shared_ptr<graph_manager::GraphManager>> graph_manager_map_;
+    std::string namespace_prefix_;
 
     std::shared_ptr<graph_manager::GraphManager> find_or_create_graph_manager(eprosima::fastdds::dds::DomainId_t domain_id);
 };

--- a/micro_ros_agent/include/agent/graph_manager/graph_manager.hpp
+++ b/micro_ros_agent/include/agent/graph_manager/graph_manager.hpp
@@ -195,6 +195,12 @@ public:
             const eprosima::fastdds::dds::DomainParticipant* participant,
             const dds::xrce::ObjectKind& entity_kind);
 
+    /**
+     * @brief   Sets the namespace prefix for all nodes.
+     * @param   namespace_prefix The namespace to prefix to all ROS nodes.
+     */
+    void set_namespace_prefix(const std::string& namespace_prefix);
+
 private:
 
     /**
@@ -280,9 +286,11 @@ private:
             std::string& node_name,
             std::string& node_namespace);
 
+private:
     eprosima::fastdds::dds::DomainId_t domain_id_;
     bool graph_changed_;
     bool display_on_change_;
+    std::string namespace_prefix_;
     std::thread microros_graph_publisher_;
     std::mutex mtx_;
     std::condition_variable cv_;

--- a/micro_ros_agent/include/agent/graph_manager/graph_manager.hpp
+++ b/micro_ros_agent/include/agent/graph_manager/graph_manager.hpp
@@ -81,7 +81,7 @@ public:
     /**
      * @brief   Default constructor.
      */
-    GraphManager(eprosima::fastdds::dds::DomainId_t domain_id, const std::string& namespace_prefix);
+    GraphManager(eprosima::fastdds::dds::DomainId_t domain_id, const std::string& namespace_prefix = "");
 
     /**
      * @brief   Default destructor.
@@ -194,6 +194,7 @@ public:
             const eprosima::fastrtps::rtps::GUID_t& entity_guid,
             const eprosima::fastdds::dds::DomainParticipant* participant,
             const dds::xrce::ObjectKind& entity_kind);
+
 private:
 
     /**

--- a/micro_ros_agent/include/agent/graph_manager/graph_manager.hpp
+++ b/micro_ros_agent/include/agent/graph_manager/graph_manager.hpp
@@ -81,7 +81,7 @@ public:
     /**
      * @brief   Default constructor.
      */
-    GraphManager(eprosima::fastdds::dds::DomainId_t domain_id);
+    GraphManager(eprosima::fastdds::dds::DomainId_t domain_id, const std::string& namespace_prefix);
 
     /**
      * @brief   Default destructor.
@@ -194,13 +194,6 @@ public:
             const eprosima::fastrtps::rtps::GUID_t& entity_guid,
             const eprosima::fastdds::dds::DomainParticipant* participant,
             const dds::xrce::ObjectKind& entity_kind);
-
-    /**
-     * @brief   Sets the namespace prefix for all nodes.
-     * @param   namespace_prefix The namespace to prefix to all ROS nodes.
-     */
-    void set_namespace_prefix(const std::string& namespace_prefix);
-
 private:
 
     /**
@@ -286,7 +279,6 @@ private:
             std::string& node_name,
             std::string& node_namespace);
 
-private:
     eprosima::fastdds::dds::DomainId_t domain_id_;
     bool graph_changed_;
     bool display_on_change_;

--- a/micro_ros_agent/include/agent/utils/namespace.hpp
+++ b/micro_ros_agent/include/agent/utils/namespace.hpp
@@ -1,24 +1,16 @@
-// MIT License
-// 
 // Copyright (c) 2020-2025 Fictionlab sp. z o.o.
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #ifndef UROS_AGENT_UTILS_NAMESPACE_HPP_
 #define UROS_AGENT_UTILS_NAMESPACE_HPP_

--- a/micro_ros_agent/include/agent/utils/namespace.hpp
+++ b/micro_ros_agent/include/agent/utils/namespace.hpp
@@ -1,16 +1,24 @@
-// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// MIT License
+// 
+// Copyright (c) 2020-2025 Fictionlab sp. z o.o.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #ifndef UROS_AGENT_UTILS_NAMESPACE_HPP_
 #define UROS_AGENT_UTILS_NAMESPACE_HPP_
@@ -41,6 +49,14 @@ public:
      * @returns True if the topic is a ROS topic with service prefixes, false otherwise.
      */
     static bool is_ros_topic(
+            const std::string& topic_name);
+
+    /**
+     * @brief   Check if a topic name is a topic that should have global namespace (eg. tf, rosout).
+     * @param   topic_name Topic name to check.
+     * @returns True if the topic is a global topic, false otherwise.
+     */
+    static bool is_global_topic(
             const std::string& topic_name);
 
     /**

--- a/micro_ros_agent/include/agent/utils/namespace.hpp
+++ b/micro_ros_agent/include/agent/utils/namespace.hpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Fictionlab sp. z o.o.
+// Copyright (c) 2025 Fictionlab sp. z o.o.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/micro_ros_agent/include/agent/utils/namespace.hpp
+++ b/micro_ros_agent/include/agent/utils/namespace.hpp
@@ -1,0 +1,71 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UROS_AGENT_UTILS_NAMESPACE_HPP_
+#define UROS_AGENT_UTILS_NAMESPACE_HPP_
+
+#include <string>
+
+namespace uros {
+namespace agent {
+namespace utils {
+
+class Namespace
+{
+private:
+    /**
+     * @brief   Default constructor. Creating instances of this class is not allowed.
+     */
+    Namespace() = default;
+
+    /**
+     * @brief   Default destructor.
+     */
+    ~Namespace() = default;
+
+public:
+    /**
+     * @brief   Check if a topic name is a ROS topic (starts with rq/, rt/, or rr/).
+     * @param   topic_name Topic name to check.
+     * @returns True if the topic is a ROS topic with service prefixes, false otherwise.
+     */
+    static bool is_ros_topic(
+            const std::string& topic_name);
+
+    /**
+     * @brief   Apply namespace to a ROS topic.
+     * @param   topic_name Original topic name.
+     * @param   namespace_prefix Namespace to apply (should start with /).
+     * @returns The topic name with namespace applied.
+     */
+    static std::string apply_namespace_to_topic(
+            const std::string& topic_name,
+            const std::string& namespace_prefix);
+
+    /**
+     * @brief   Apply namespace to a ROS node.
+     * @param   node_name Original node name.
+     * @param   namespace_prefix Namespace to apply (should start with /).
+     * @returns The node name with namespace applied.
+     */
+    static std::string apply_namespace_to_node(
+            const std::string& node_namespace,
+            const std::string& namespace_prefix);
+};
+
+}  // namespace utils
+}  // namespace agent
+}  // namespace uros
+
+#endif  // UROS_AGENT_UTILS_NAMESPACE_HPP_

--- a/micro_ros_agent/src/agent/Agent.cpp
+++ b/micro_ros_agent/src/agent/Agent.cpp
@@ -35,7 +35,7 @@ bool Agent::create(
 {
     for (int i = 1; i < argc - 1; ++i)
     {
-        if (strcmp(argv[i], "-n") == 0 || strcmp(argv[i], "--namespace") == 0)
+        if (strcmp(argv[i], "-n") == 0 || strcmp(argv[i], "--namespace-prefix") == 0)
         {
             namespace_prefix_ = std::string(argv[i + 1]);
             if (namespace_prefix_.empty() || namespace_prefix_[0] != '/')
@@ -333,18 +333,11 @@ auto it = graph_manager_map_.find(domain_id);
 
     if (it != graph_manager_map_.end()) {
         return it->second;
-    }else{
-        auto graph_manager = std::make_shared<graph_manager::GraphManager>(domain_id);
-        // Set namespace prefix if one was specified
-        if (!namespace_prefix_.empty())
-        {
-            graph_manager->set_namespace_prefix(namespace_prefix_);
-        }
-        
+    }else{        
         return graph_manager_map_.insert(
             std::make_pair(
                 domain_id,
-                graph_manager
+                std::make_shared<graph_manager::GraphManager>(domain_id, namespace_prefix_)
             )
         ).first->second;
     }

--- a/micro_ros_agent/src/agent/Agent.cpp
+++ b/micro_ros_agent/src/agent/Agent.cpp
@@ -333,7 +333,7 @@ auto it = graph_manager_map_.find(domain_id);
 
     if (it != graph_manager_map_.end()) {
         return it->second;
-    }else{        
+    }else{
         return graph_manager_map_.insert(
             std::make_pair(
                 domain_id,

--- a/micro_ros_agent/src/agent/Agent.cpp
+++ b/micro_ros_agent/src/agent/Agent.cpp
@@ -211,17 +211,21 @@ bool Agent::create(
             std::move(on_create_requester));
 
         /**
-         * Add CREATE_TOPIC callback.
+         * Add PRE_CREATE_TOPIC callback.
          */
-        std::function<void (eprosima::fastrtps::TopicAttributes&)> on_create_topic
-            ([&](eprosima::fastrtps::TopicAttributes& attrs) -> void
+        std::function<void (
+            const eprosima::fastdds::dds::DomainParticipant *,
+            eprosima::fastrtps::TopicAttributes *)> pre_create_topic
+            ([&](const eprosima::fastdds::dds::DomainParticipant *participant,
+                  eprosima::fastrtps::TopicAttributes *attrs) -> void
             {
-                attrs.topicName = utils::Namespace::apply_namespace_to_topic(attrs.getTopicName().c_str(), namespace_prefix_);
+                (void)participant;
+                attrs->topicName = utils::Namespace::apply_namespace_to_topic(attrs->getTopicName().c_str(), namespace_prefix_);
             });
         xrce_dds_agent_instance_.add_middleware_callback(
             eprosima::uxr::Middleware::Kind::FASTDDS,
-            eprosima::uxr::middleware::CallbackKind::CREATE_TOPIC,
-            std::move(on_create_topic));
+            eprosima::uxr::middleware::CallbackKind::PRE_CREATE_TOPIC,
+            std::move(pre_create_topic));
 
         /**
          * Add DELETE_REQUESTER callback.

--- a/micro_ros_agent/src/agent/Agent.cpp
+++ b/micro_ros_agent/src/agent/Agent.cpp
@@ -16,6 +16,7 @@
 #define _UROS_AGENT_AGENT_CPP
 
 #include <agent/Agent.hpp>
+#include <agent/utils/namespace.hpp>
 
 #include <utility>
 #include <memory>
@@ -32,6 +33,23 @@ bool Agent::create(
         int argc,
         char** argv)
 {
+    for (int i = 1; i < argc - 1; ++i)
+    {
+        if (strcmp(argv[i], "-n") == 0 || strcmp(argv[i], "--namespace") == 0)
+        {
+            namespace_prefix_ = std::string(argv[i + 1]);
+            if (namespace_prefix_.empty() || namespace_prefix_[0] != '/')
+            {
+                namespace_prefix_ = "/" + namespace_prefix_;
+            }
+            if (namespace_prefix_.length() > 1 && namespace_prefix_.back() == '/')
+            {
+                namespace_prefix_.pop_back();
+            }
+            break;
+        }
+    }
+
     bool result = xrce_dds_agent_instance_.create(argc, argv);
     if (result)
     {
@@ -193,6 +211,19 @@ bool Agent::create(
             std::move(on_create_requester));
 
         /**
+         * Add CREATE_TOPIC callback.
+         */
+        std::function<void (eprosima::fastrtps::TopicAttributes&)> on_create_topic
+            ([&](eprosima::fastrtps::TopicAttributes& attrs) -> void
+            {
+                attrs.topicName = utils::Namespace::apply_namespace_to_topic(attrs.getTopicName().c_str(), namespace_prefix_);
+            });
+        xrce_dds_agent_instance_.add_middleware_callback(
+            eprosima::uxr::Middleware::Kind::FASTDDS,
+            eprosima::uxr::middleware::CallbackKind::CREATE_TOPIC,
+            std::move(on_create_topic));
+
+        /**
          * Add DELETE_REQUESTER callback.
          */
         std::function<void (
@@ -299,10 +330,17 @@ auto it = graph_manager_map_.find(domain_id);
     if (it != graph_manager_map_.end()) {
         return it->second;
     }else{
+        auto graph_manager = std::make_shared<graph_manager::GraphManager>(domain_id);
+        // Set namespace prefix if one was specified
+        if (!namespace_prefix_.empty())
+        {
+            graph_manager->set_namespace_prefix(namespace_prefix_);
+        }
+        
         return graph_manager_map_.insert(
             std::make_pair(
                 domain_id,
-                std::make_shared<graph_manager::GraphManager>(domain_id)
+                graph_manager
             )
         ).first->second;
     }

--- a/micro_ros_agent/src/agent/graph_manager/graph_manager.cpp
+++ b/micro_ros_agent/src/agent/graph_manager/graph_manager.cpp
@@ -16,6 +16,7 @@
 #define _UROS_AGENT_GRAPH_MANAGER_CPP
 
 #include <agent/graph_manager/graph_manager.hpp>
+#include <agent/utils/namespace.hpp>
 
 #include <memory>
 #include <string>
@@ -594,6 +595,16 @@ void GraphManager::get_name_and_namespace(
         node_name = participant_name;
         node_namespace = "/";
     }
+
+    if (!namespace_prefix_.empty() && namespace_prefix_ != "/")
+    {
+        node_namespace = utils::Namespace::apply_namespace_to_node(node_namespace, namespace_prefix_);
+    }
+}
+
+void GraphManager::set_namespace_prefix(const std::string& namespace_prefix)
+{
+    namespace_prefix_ = namespace_prefix;
 }
 
 GraphManager::ParticipantListener::ParticipantListener(

--- a/micro_ros_agent/src/agent/graph_manager/graph_manager.cpp
+++ b/micro_ros_agent/src/agent/graph_manager/graph_manager.cpp
@@ -27,10 +27,11 @@ namespace uros {
 namespace agent {
 namespace graph_manager {
 
-GraphManager::GraphManager(eprosima::fastdds::dds::DomainId_t domain_id)
+GraphManager::GraphManager(eprosima::fastdds::dds::DomainId_t domain_id, const std::string& namespace_prefix)
     : domain_id_(domain_id)
     , graph_changed_(false)
     , display_on_change_(false)
+    , namespace_prefix_(namespace_prefix)
     , mtx_()
     , cv_()
     , graphCache_()
@@ -600,11 +601,6 @@ void GraphManager::get_name_and_namespace(
     {
         node_namespace = utils::Namespace::apply_namespace_to_node(node_namespace, namespace_prefix_);
     }
-}
-
-void GraphManager::set_namespace_prefix(const std::string& namespace_prefix)
-{
-    namespace_prefix_ = namespace_prefix;
 }
 
 GraphManager::ParticipantListener::ParticipantListener(

--- a/micro_ros_agent/src/agent/utils/namespace.cpp
+++ b/micro_ros_agent/src/agent/utils/namespace.cpp
@@ -1,16 +1,24 @@
-// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// MIT License
+// 
+// Copyright (c) 2020-2025 Fictionlab sp. z o.o.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 #ifndef UROS_AGENT_UTILS_NAMESPACE_CPP_
 #define UROS_AGENT_UTILS_NAMESPACE_CPP_
@@ -30,11 +38,24 @@ bool Namespace::is_ros_topic(
              topic_name.substr(0, 3) == "rr/"));
 }
 
+bool Namespace::is_global_topic(
+        const std::string& topic_name)
+{
+    return (topic_name == "/tf" || 
+            topic_name == "/tf_static" || 
+            topic_name == "/diagnostics" || 
+            topic_name == "/rosout" || 
+            topic_name == "/parameter_events");
+}
+
 std::string Namespace::apply_namespace_to_topic(
         const std::string& topic_name,
         const std::string& namespace_prefix)
 {
-    if (namespace_prefix.empty() || namespace_prefix == "/" || !is_ros_topic(topic_name))
+    if (namespace_prefix.empty() || 
+        namespace_prefix == "/" || 
+        !is_ros_topic(topic_name) || 
+        is_global_topic(topic_name.substr(2)))
     {
         return topic_name;
     }

--- a/micro_ros_agent/src/agent/utils/namespace.cpp
+++ b/micro_ros_agent/src/agent/utils/namespace.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 Fictionlab sp. z o.o.
+// Copyright (c) 2025 Fictionlab sp. z o.o.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/micro_ros_agent/src/agent/utils/namespace.cpp
+++ b/micro_ros_agent/src/agent/utils/namespace.cpp
@@ -1,24 +1,16 @@
-// MIT License
-// 
 // Copyright (c) 2020-2025 Fictionlab sp. z o.o.
-// 
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-// 
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-// 
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #ifndef UROS_AGENT_UTILS_NAMESPACE_CPP_
 #define UROS_AGENT_UTILS_NAMESPACE_CPP_

--- a/micro_ros_agent/src/agent/utils/namespace.cpp
+++ b/micro_ros_agent/src/agent/utils/namespace.cpp
@@ -1,0 +1,66 @@
+// Copyright 2020 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef UROS_AGENT_UTILS_NAMESPACE_CPP_
+#define UROS_AGENT_UTILS_NAMESPACE_CPP_
+
+#include <agent/utils/namespace.hpp>
+
+namespace uros {
+namespace agent {
+namespace utils {
+
+bool Namespace::is_ros_topic(
+        const std::string& topic_name)
+{
+    return (topic_name.length() >= 3 &&
+            (topic_name.substr(0, 3) == "rq/" || 
+             topic_name.substr(0, 3) == "rt/" || 
+             topic_name.substr(0, 3) == "rr/"));
+}
+
+std::string Namespace::apply_namespace_to_topic(
+        const std::string& topic_name,
+        const std::string& namespace_prefix)
+{
+    if (namespace_prefix.empty() || namespace_prefix == "/" || !is_ros_topic(topic_name))
+    {
+        return topic_name;
+    }
+
+    std::string service_prefix = topic_name.substr(0, 2);
+    std::string remaining_topic = topic_name.substr(2);
+                
+    return service_prefix + namespace_prefix + remaining_topic;
+}
+
+std::string Namespace::apply_namespace_to_node(
+        const std::string& node_namespace,
+        const std::string& namespace_prefix)
+{
+        if (node_namespace == "/")
+        {
+            return namespace_prefix;
+        }
+        else
+        {
+            return namespace_prefix + node_namespace;
+        }
+}
+
+}  // namespace utils
+}  // namespace agent
+}  // namespace uros
+
+#endif  // UROS_AGENT_UTILS_NAMESPACE_CPP_


### PR DESCRIPTION
Node, topic and service namespaces can be added with help from custom XCRE-DDS Agent. Namespaces is passed via `-n` or `--namespace` arguments. Any configuration with (or without) a slash is allowed, e.g.: `-n /namespace` `-n namespace` or `-n /namespace/`